### PR TITLE
Fix empty row bug

### DIFF
--- a/integration_tests/test_gsheets_integration.py
+++ b/integration_tests/test_gsheets_integration.py
@@ -196,3 +196,7 @@ def test_read_new_data(new_people, attrib, rick_val, morty_val):
     new_morty = new_people[1]
     assert getattr(new_rick, attrib) == rick_val
     assert getattr(new_morty, attrib) == morty_val
+
+
+def test_count_people(people):
+    assert len(people) == 2

--- a/pygsheetsorm/pygsheetsorm.py
+++ b/pygsheetsorm/pygsheetsorm.py
@@ -313,7 +313,11 @@ class Repository(object):
         """
         # Only get new models if none are cached
         if not self._models:
-            rows = self.worksheet.get_all_values(returnas="cells")
+            rows = self.worksheet.get_all_values(
+                include_tailing_empty=False,
+                include_tailing_empty_rows=False,
+                returnas="cells",
+            )
             # Skip header row and iterate over cells
             for row in rows[1:]:
                 model = self._get_model_from_row(row)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "Programming Language :: Python :: 3.6",
     ],
     description="Easy to use library to map a Google Sheet Worksheet to a Python object.",
-    version="1.0.0",
+    version="1.0.1",
     url="https://github.com/salesforce/pygsheetsorm",
     license="BSD 3-clause",
     packages=["pygsheetsorm"],

--- a/tests/test_pygsheetsorm.py
+++ b/tests/test_pygsheetsorm.py
@@ -202,3 +202,33 @@ def test_repo_populates_boolean_in_model(full_repo):
     models = full_repo.get_all()
     assert models[2].header_row_1_column_1 == True
     assert models[2].header_row_1_column_2 == False
+
+
+@pytest.fixture
+def repo_header_only():
+    # Creates a repo with models based on the following data:
+    #
+    # | header row 1 column 1 | header row 1 column 2 |
+    # |-----------------------|-----------------------|
+    #
+    mock_worksheet = mock.create_autospec(pygsheets.Worksheet)
+    row = []
+    row_index = 0
+    for column_index in range(1, 3):
+        value = "row {} column {}".format(row_index, column_index)
+        if row_index == 1:
+            value = "header " + value
+        cell = get_mock_cell(
+            column_number=column_index, row_number=row_index, value=value
+        )
+        row.append(cell)
+    rows = [row]
+    mock_worksheet.get_all_values.return_value = rows
+    mock_worksheet.get_row.return_value = rows[0]
+    repo = Repository(pygsheets_worksheet=mock_worksheet)
+    return repo
+
+
+def test_header_only(repo_header_only):
+    models = repo_header_only.get_all()
+    assert len(models) == 0


### PR DESCRIPTION
Using the new pygsheets version returns empty rows unless we add another attribute to the api calls. This returns pygsheetsorm to the original behvaior of not returning empty rows.