### PR TITLE
Fix UnboundLocalError: local variable 'row_number'

### DIFF
--- a/pygsheetsorm/pygsheetsorm.py
+++ b/pygsheetsorm/pygsheetsorm.py
@@ -338,6 +338,7 @@ class Repository(object):
 
         # Empty cells don't get returned so we create empties to work with
         columns_to_add = set(list(self._col_to_property_name.keys()))
+        row_number = 0
         for cell in row:
             row_number = cell.row  # When we fill in emptyies, we need this
             try:


### PR DESCRIPTION
Fix UnboundLocalError: local variable 'row_number' referenced before assignment

```
Traceback (most recent call last):
  File "main.py", line 11, in <module>
    meters = repo.get_all()
  File "pygsheetsorm/pygsheetsorm.py", line 323, in get_all
    model = self._get_model_from_row(row)
  File "pygsheetsorm/pygsheetsorm.py", line 351, in _get_model_from_row
    cell_pos = (row_number, column_number)
UnboundLocalError: local variable 'row_number' referenced before assignment
```

This caused by empty but formatted with borders rows
|Header|
|---|
|value 1|
|value 2|
|_empty border only_|
|_empty border only_|
